### PR TITLE
Updated MOD file to fix the issue with the upcoming NEURON 9.0 release

### DIFF
--- a/cdp5.mod
+++ b/cdp5.mod
@@ -100,11 +100,10 @@ ASSIGNED {
 	parea     (um)     : pump area per unit length
 	parea2	  (um)
 	cai       (mM)
+	cao       (mM)
 	mgi	(mM)
 	vrat	(1)	
 }
-
-: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/cdp5.mod
+++ b/cdp5.mod
@@ -104,7 +104,7 @@ ASSIGNED {
 	vrat	(1)	
 }
 
-CONSTANT { cao = 2	(mM) }
+: CONSTANT { cao = 2	(mM) }
 
 STATE {
 	: ca[0] is equivalent to cai

--- a/readme.html
+++ b/readme.html
@@ -35,4 +35,8 @@ respectively.
 <img src="./screenshot_hyp.png" alt="screenshot hyperpolarized">
 <p/>Intermediate:<p/>
 <img src="./screenshot_int.png" alt="screenshot intermediate">
+Changelog<br/>
+----------<p/>
+* cdp5.mod is updated due to issue mentioned in https://github.com/neuronsimulator/nrn/pull/1955.
+   CONSTANT block has no effect in the initialization of ion variables.
 </html>


### PR DESCRIPTION
USEION variable can not be initialized in a CONSTANT block.
See https://github.com/neuronsimulator/nrn/pull/1955.